### PR TITLE
Fixes for AbstractLevelDown 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,9 @@ var toBuffer = require('typedarray-to-buffer')
 
 function Level(location) {
   if (!(this instanceof Level)) return new Level(location)
-  if (!location) throw new Error("constructor requires at least a location argument")
+
+  AbstractLevelDOWN.call(this, location)
+
   this.IDBOptions = {}
   this.location = location
 }


### PR DESCRIPTION
This partially solves the problems with AbstractLevelDown 2 (at least the initialization)

Unfortunately, the new feature "support for `null` values", needs to be implemented in a not-backward compatible way. Basically IDBWrapper returns `null` if a key is not found, so it is impossible to tell if the specified value is `null` or if there is no key.

I am not sure if exposing this difference in IDBWrapper is possible, and I had no time to look at this issue further

I recommend:
1. Release 2.2.1 with the old AbstractLevelDown
2. Fix the NULL value support and release it as level-js 3.

Also cc @JamesKyburz and @jprichardson @juliangruber 
