### PR TITLE
Iterator refactor

### DIFF
--- a/iterator.js
+++ b/iterator.js
@@ -9,10 +9,12 @@ function Iterator (db, options) {
   this.options = options
   AbstractIterator.call(this, db)
   this._order = options.reverse ? 'DESC': 'ASC'
-  this._limit = options.limit
-  if (!this._limit || this._limit === -1) {
+  this._limit = options.limit;
+  if (this._limit == null || this._limit === -1) {
     this._limit = Infinity;
   }
+  if (typeof this._limit !== 'number') throw new TypeError('options.limit must be a number')
+  if (this._limit === 0) return // skip further processing and wait for first call to _next
 
   this._count = 0
   this._done  = false
@@ -85,7 +87,7 @@ Iterator.prototype.onItem = function (value, cursor, cursorTransaction) {
 }
 
 Iterator.prototype._next = function (callback) {
-  if (this._keyRangeError) return callback()
+  if (this._keyRangeError || this._limit === 0) return callback()
 
   if (this._emitAndContinue) {
     this._emitAndContinue(callback)

--- a/test/custom-tests.js
+++ b/test/custom-tests.js
@@ -75,4 +75,19 @@ module.exports.all = function(leveljs, tape, testCommon) {
     })
   })
 
+  tape('zero results if gt key > lt key', function(t) {
+    var level = levelup('key-range-test', {db: leveljs})
+    level.open(function(err) {
+      t.notOk(err, 'no error')
+      var s = level.createReadStream({ gte: 'x', lt: 'b' });
+      var item;
+      s.on('readable', function() {
+        item = s.read()
+      })
+      s.on('end', function() {
+        t.end()
+      });
+    })
+  })
+
 }


### PR DESCRIPTION
Did some refactor of the iterator to fix the tests and fix some minor issues.

commit d9605d48444ffe0724aed52c284a4b8c2a91dae1
Author: Tim Kuijsten
Date:   Fri Feb 5 01:17:42 2016 +0100

```
fix iterator when limit is 0

uncovered when testing with abstract-leveldown2 tests
```

commit 6ac2eb82be99132ceeca2cda2b4c6b05222fa1c9
Author: Tim Kuijsten
Date:   Fri Feb 5 00:53:49 2016 +0100

```
add test to check for key range error handling
```

commit c1b642862c48c0f59cdd16b115a92c339e7758ed
Author: Tim Kuijsten
Date:   Fri Feb 5 00:25:50 2016 +0100

```
refactor iterator, multiple fixes, make tests pass

Fixes #43 #40 and #3. Unfortunately not easy to split out in separate commits.

1. maxogden/level.js#43 "snapshots seem not to work"

The reason snapshots didn't work in the test, is because the iterator was only
opened on the first call to _next. The new version opens the iterator right
away in the constructor (if there is no KeyRange error).

2. maxogden/level.js#40 "abstract-leveldown tests aren't all passing anymore"

Partially fixed by merging PR #42 and further fixed by this commit.

3. maxogden/level.js#3 "stop batch reads after limit is reached"

The solution is stop calling cursor.continue() once the limit is reached. The
transaction will automatically timeout as prescribed by the spec. idb-wrapper
can't be used for this because limit is only respected if autoContinue is true.

All 563 tests pass on:
* Safari 9.0.3
* Firefox 45.0b2
* Firefox 46.0a2
* Iridium 44.1 (Chrome/44.0.2403.157)
```

commit bfe717b8106c0902a380c94be9fb0b48e1011a6b
Merge: 2c72508 7939006
Author: Tim Kuijsten
Date:   Fri Feb 5 00:20:23 2016 +0100

```
Merge remote-tracking branch 'upstream/fix-for-new-abstract-leveldown'

relates to maxogden/level.js#40

fixes the problem with keys. doesn't fix the problem with snapshots
```

commit 79390060ed591180a7c2de717631d96282e67ed8
Author: Julian Gruber
Date:   Tue Jul 7 09:24:34 2015 +0200

```
iterator: data as buffers by default
```
