### PR TITLE
Actually support overriding default options

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ Level.prototype._open = function(options, callback) {
     }
   }
   
-  xtend(idbOpts, options)
+  idbOpts = xtend(idbOpts, options)
   this.IDBOptions = idbOpts
   this.idb = new IDB(idbOpts)
 }


### PR DESCRIPTION
Thank you for a great library!

At a glance, the current code _looks_ like it would work but `xtend` does not modify the first argument; it always returns a new object.

I ran into this because I wanted to override the `IndexedDB` name used so I can query for indexes other than the primary key as part of a [Serverless Issue-tracking Board](https://github.com/philschatz/gh-board) side-project.
