### PR TITLE
xtend@^4.0.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var AbstractLevelDOWN = require('abstract-leveldown').AbstractLevelDOWN
 var util = require('util')
 var Iterator = require('./iterator')
 var isBuffer = require('isbuffer')
-var xtend = require('xtend')
+var xtend = require('xtend/mutable')
 var toBuffer = require('typedarray-to-buffer')
 
 function Level(location) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "isbuffer": "~0.0.0",
     "ltgt": "^2.1.2",
     "typedarray-to-buffer": "~1.0.0",
-    "xtend": "~2.1.2"
+    "xtend": "^4.0.1"
   },
   "testling": {
     "files": "test/test.js",


### PR DESCRIPTION
Bumps xtend to locked v4. Was back on v2, prior to much goodness.
