### PR TITLE
Upgrade

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,10 +128,6 @@ Level.prototype._approximateSize = function (start, end, callback) {
   throw err
 }
 
-Level.prototype._isBuffer = function (obj) {
-  return Buffer.isBuffer(obj)
-}
-
 Level.destroy = function (db, callback) {
   if (typeof db === 'object') {
     var prefix = db.IDBOptions.storePrefix || 'IDBWrapper-'

--- a/index.js
+++ b/index.js
@@ -80,8 +80,7 @@ Level.prototype._serializeValue = function (value, options) {
   return value
 }
 
-Level.prototype.iterator = function (options) {
-  if (typeof options !== 'object') options = {}
+Level.prototype._iterator = function (options) {
   return new Iterator(this.idb, options)
 }
 

--- a/index.js
+++ b/index.js
@@ -88,8 +88,7 @@ Level.prototype._serializeKey = function (key) {
   return String(key)
 }
 
-// NOTE: doesn't match abstract signature yet (which has no options argument).
-Level.prototype._serializeValue = function (value, options) {
+Level.prototype._serializeValue = function (value) {
   // TODO: do we still need to support ArrayBuffer?
   if (value instanceof ArrayBuffer) return Buffer.from(value)
   if (value == null) return ''

--- a/index.js
+++ b/index.js
@@ -120,14 +120,6 @@ Level.prototype._close = function (callback) {
   callback()
 }
 
-Level.prototype._approximateSize = function (start, end, callback) {
-  var err = new Error('Not implemented')
-  if (callback)
-    return callback(err)
-
-  throw err
-}
-
 Level.destroy = function (db, callback) {
   if (typeof db === 'object') {
     var prefix = db.IDBOptions.storePrefix || 'IDBWrapper-'

--- a/index.js
+++ b/index.js
@@ -43,14 +43,12 @@ Level.prototype._get = function (key, options, callback) {
       // 'NotFound' error, consistent with LevelDOWN API
       return callback(new Error('NotFound'))
     }
-    // by default return buffers, unless explicitly told not to
-    var asBuffer = true
-    if (options.asBuffer === false) asBuffer = false
-    if (options.raw) asBuffer = false
-    if (asBuffer) {
+
+    if (options.asBuffer) {
       if (value instanceof Uint8Array) value = toBuffer(value)
       else value = Buffer.from(String(value))
     }
+
     return callback(null, value, key)
   }, callback)
 }
@@ -97,12 +95,6 @@ Level.prototype._serializeValue = function (value, options) {
   // TODO: do we still need to support ArrayBuffer?
   if (value instanceof ArrayBuffer) return Buffer.from(value)
   if (value == null) return ''
-
-  // TODO: remove
-  if (options.raw) return value
-
-  // TODO: remove
-  if (typeof value !== 'object') return value.toString()
 
   return value
 }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ var toBuffer = require('typedarray-to-buffer')
 
 function Level(location) {
   if (!(this instanceof Level)) return new Level(location)
-  if (!location) throw new Error("constructor requires at least a location argument")
+  AbstractLevelDOWN.call(this, location)
   this.IDBOptions = {}
   this.location = location
 }

--- a/index.js
+++ b/index.js
@@ -58,8 +58,6 @@ Level.prototype._del = function(id, options, callback) {
 }
 
 Level.prototype._put = function (key, value, options, callback) {
-  // TODO: once we upgrade abstract-leveldown, it will call _serializeValue for us.
-  value = this._serializeValue(value, options)
   this.idb.put(key, value, function() { callback() }, callback)
 }
 
@@ -117,9 +115,6 @@ Level.prototype._batch = function (array, options, callback) {
     copiedOp = {}
     currentOp = array[i]
     modified[i] = copiedOp
-
-    // TODO: once we upgrade abstract-leveldown, it will call _serializeValue for us.
-    currentOp.value = this._serializeValue(currentOp.value, options)
 
     for (k in currentOp) {
       if (k === 'type' && currentOp[k] == 'del') {

--- a/iterator.js
+++ b/iterator.js
@@ -18,14 +18,20 @@ function Iterator (db, options) {
   AbstractIterator.call(this, db)
 
   this._order = options.reverse ? 'DESC': 'ASC'
-  this._limit = options.limit || -1
+  this._limit = options.limit
   this._count = 0
   this._callback = null
   this._cache = []
   this._completed = false
+  this.transaction = null
 
   this._keyAsBuffer = options.keyAsBuffer
   this._valueAsBuffer = options.valueAsBuffer
+
+  if (this._limit === 0) {
+    this._completed = true
+    return
+  }
 
   var lower = ltgt.lowerBound(options)
   var upper = ltgt.upperBound(options)
@@ -97,7 +103,7 @@ Iterator.prototype._next = function (callback) {
   // TODO: can remove this after upgrading abstract-leveldown
   if (!callback) throw new Error('next() requires a callback argument')
 
-  if (this.transaction.error !== null) {
+  if (this.transaction !== null && this.transaction.error !== null) {
     var err = this.transaction.error
 
     setTimeout(function() {

--- a/iterator.js
+++ b/iterator.js
@@ -24,9 +24,8 @@ function Iterator (db, options) {
   this._cache = []
   this._completed = false
 
-  // TODO: in later abstract-leveldown, these have proper defaults
-  this._keyAsBuffer = options.keyAsBuffer !== false
-  this._valueAsBuffer = options.valueAsBuffer !== false
+  this._keyAsBuffer = options.keyAsBuffer
+  this._valueAsBuffer = options.valueAsBuffer
 
   var lower = ltgt.lowerBound(options)
   var upper = ltgt.upperBound(options)

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "airtap": "0.0.5",
     "brfs": "~1.6.1",
     "browserify": "~16.2.2",
+    "encoding-down": "~5.0.2",
     "levelup": "~3.0.0",
     "tape": "^4.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "tape": "^4.0.0"
   },
   "dependencies": {
-    "abstract-leveldown": "~0.12.0",
+    "abstract-leveldown": "~5.0.0",
     "idb-wrapper": "^1.5.0",
     "isbuffer": "~0.0.0",
     "ltgt": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "airtap": "0.0.5",
+    "brfs": "~1.6.1",
     "browserify": "~16.2.2",
     "levelup": "~3.0.0",
     "tape": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "airtap": "0.0.5",
     "browserify": "~16.2.2",
-    "levelup": "~0.18.2",
+    "levelup": "~3.0.0",
     "tape": "^4.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "license": "MIT",
   "devDependencies": {
     "airtap": "0.0.5",
-    "brfs": "~1.6.1",
     "browserify": "~16.2.2",
     "encoding-down": "~5.0.2",
     "levelup": "~3.0.0",

--- a/test/custom-tests.js
+++ b/test/custom-tests.js
@@ -59,6 +59,31 @@ module.exports.all = function(leveljs, tape, testCommon) {
     })
   })
 
+  // Adapted from a memdown test.
+  tape('iterator stringifies buffer input', function (t) {
+    t.plan(6)
+
+    var db = leveljs(testCommon.location())
+
+    db.open(function (err) {
+      t.ifError(err, 'no open error')
+
+      db.put(1, 2, function (err) {
+        t.ifError(err, 'no put error')
+
+        testCommon.collectEntries(db.iterator(), function (err, entries) {
+          t.ifError(err, 'no iterator error')
+          t.same(entries[0].key, Buffer.from('1'), 'key is stringified')
+          t.same(entries[0].value, Buffer.from('2'), 'value is stringified')
+
+          db.close(function (err) {
+            t.ifError(err, 'no close error')
+          })
+        })
+      })
+    })
+  })
+
   // TODO: merge this and the test below. Test all types.
   tape('store native JS types', function(t) {
     var level = leveljs(testCommon.location())

--- a/test/custom-tests.js
+++ b/test/custom-tests.js
@@ -21,15 +21,14 @@ module.exports.all = function(leveljs, tape, testCommon) {
     })
   })
 
-  // TODO: this should be supported without raw: true. Which is possible once
-  // we upgrade abstract-leveldown (which only tests strings and Buffers now).
-  tape('store native JS types with raw = true', function(t) {
+  // TODO: merge this and the test below. Test all types.
+  tape('store native JS types', function(t) {
     var level = leveljs(testCommon.location())
     level.open(function(err) {
       t.notOk(err, 'no error')
-      level.put('key', true, { raw: true },  function (err) {
+      level.put('key', true, function (err) {
         t.notOk(err, 'no error')
-        level.get('key', { raw: true }, function(err, value) {
+        level.get('key', { asBuffer: false }, function(err, value) {
           t.notOk(err, 'no error')
           t.ok(typeof value === 'boolean', 'is boolean type')
           t.ok(value, 'is truthy')
@@ -45,9 +44,9 @@ module.exports.all = function(leveljs, tape, testCommon) {
     var level = leveljs(testCommon.location())
     level.open(function(err) {
       t.notOk(err, 'no error')
-      level.put('key', NaN, { raw: true }, function (err) {
+      level.put('key', NaN, function (err) {
         t.notOk(err, 'no error')
-        level.get('key', { raw: true }, function(err, value) {
+        level.get('key', { asBuffer: false }, function(err, value) {
           t.notOk(err, 'no error')
           t.ok(Number.isNaN(value), 'is NaN')
           level.close(t.end.bind(t))

--- a/test/custom-tests.js
+++ b/test/custom-tests.js
@@ -60,20 +60,20 @@ module.exports.all = function(leveljs, tape, testCommon) {
 
   tape('test levelup .destroy w/ string', function(t) {
     var location = testCommon.location()
-    var level = levelup(location, {db: leveljs})
-    level.put('key', 'value', function (err) {
+    var db = levelup(leveljs(location))
+    db.put('key', 'value', function (err) {
       t.notOk(err, 'no error')
-      level.get('key', function (err, value) {
+      db.get('key', { asBuffer: false }, function (err, value) {
         t.notOk(err, 'no error')
         t.equal(value, 'value', 'should have value')
-        level.close(function (err) {
+        db.close(function (err) {
           t.notOk(err, 'no error')
           leveljs.destroy(location, function (err) {
             t.notOk(err, 'no error')
-            var level2 = levelup(location, {db: leveljs})
-            level2.get('key', function (err, value) {
-              t.ok(err, 'key is not there')
-              level2.close(t.end.bind(t))
+            var db2 = levelup(leveljs(location))
+            db2.get('key', { asBuffer: false }, function (err, value) {
+              t.ok(err && err.notFound, 'key is not there')
+              db2.close(t.end.bind(t))
             })
           })
         })
@@ -83,20 +83,20 @@ module.exports.all = function(leveljs, tape, testCommon) {
 
   tape('test levelup .destroy w/ db instance', function(t) {
     var location = testCommon.location()
-    var level = levelup(location, {db: leveljs})
-    level.put('key', 'value', function (err) {
+    var db = levelup(leveljs(location))
+    db.put('key', 'value', function (err) {
       t.notOk(err, 'no error')
-      level.get('key', function (err, value) {
+      db.get('key', { asBuffer: false }, function (err, value) {
         t.notOk(err, 'no error')
         t.equal(value, 'value', 'should have value')
-        level.close(function (err) {
+        db.close(function (err) {
           t.notOk(err, 'no error')
-          leveljs.destroy(level.db, function (err) {
+          leveljs.destroy(db.db, function (err) {
             t.notOk(err, 'no error')
-            var level2 = levelup(location, {db: leveljs})
-            level2.get('key', function (err, value) {
-              t.ok(err, 'key is not there')
-              level2.close(t.end.bind(t))
+            var db2 = levelup(leveljs(location))
+            db2.get('key', { asBuffer: false }, function (err, value) {
+              t.ok(err && err.notFound, 'key is not there')
+              db2.close(t.end.bind(t))
             })
           })
         })

--- a/test/custom-tests.js
+++ b/test/custom-tests.js
@@ -22,7 +22,7 @@ module.exports.all = function(leveljs, tape, testCommon) {
   // This should be covered by abstract-leveldown tests, but that's
   // prevented by process.browser checks (Level/abstract-leveldown#121).
   // This test is adapted from memdown.
-  tape('buffer keys', function (t) {
+  leveljs.binaryKeys && tape('buffer keys', function (t) {
     var db = leveljs(testCommon.location())
 
     db.open(function (err) {
@@ -60,7 +60,7 @@ module.exports.all = function(leveljs, tape, testCommon) {
   })
 
   // Adapted from a memdown test.
-  tape('iterator stringifies buffer input', function (t) {
+  leveljs.binaryKeys && tape('iterator stringifies buffer input', function (t) {
     t.plan(6)
 
     var db = leveljs(testCommon.location())

--- a/test/test-levelup.js
+++ b/test/test-levelup.js
@@ -1,27 +1,25 @@
 /*** Levelup tests
-  Temporary to test integration, can be removed later.
+  NOTE: Temporary integration tests, can be removed later. Remember
+  to also remove the encoding-down devDependency.
 ***/
 var levelup = require('levelup')
+var encoding = require('encoding-down')
 var leveljs = require('../')
 var test = require('tape')
 var testCommon = require('./testCommon')
-
-function identity (v) {
-  return v
-}
 
 test('setup', testCommon.setUp)
 
 test('levelup put', function (t) {
   t.plan(4)
 
-  // TODO: update signature after upgrading levelup
-  var db = levelup(testCommon.location(), { db: leveljs })
+  var down = leveljs(testCommon.location())
+  var db = levelup(down)
 
   db.put('name', 'LevelUP string', function (err) {
     t.ifError(err, 'no put error')
 
-    db.get('name', function (err, value) {
+    db.get('name', { asBuffer: false }, function (err, value) {
       t.ifError(err, 'no get error')
       t.is(value, 'LevelUP string')
 
@@ -33,10 +31,10 @@ test('levelup put', function (t) {
 })
 
 test('binary', function (t) {
-  t.plan(6)
+  t.plan(9)
 
-  // TODO: update signature after upgrading levelup
-  var db = levelup(testCommon.location(), { db: leveljs, valueEncoding: 'binary' })
+  var down = leveljs(testCommon.location())
+  var db = levelup(encoding(down, { valueEncoding: 'binary' }))
   var buf = Buffer.from('00ff', 'hex')
 
   db.put('binary', buf, function (err) {
@@ -44,14 +42,14 @@ test('binary', function (t) {
 
     db.get('binary', function (err, value) {
       t.ifError(err, 'no get error')
+      t.ok(Buffer.isBuffer(value), 'is a buffer')
+      t.same(value, buf)
 
-      // This levelup is really old and its binary decoder does:
-      // `return process.browser ? buffer.toString(type) : buffer`
-      t.notOk(Buffer.isBuffer(value), 'not a buffer')
-
-      db.get('binary', { valueEncoding: { decode: identity } }, function (err, value) {
+      db.get('binary', { valueEncoding: 'id' }, function (err, value) {
         t.ifError(err, 'no get error')
-        t.ok(Buffer.isBuffer(value), 'is a buffer')
+        t.notOk(Buffer.isBuffer(value), 'is not a buffer')
+        t.ok(value instanceof Uint8Array, 'is a Uint8Array')
+        t.same(Buffer.from(value), buf)
 
         db.close(function (err) {
           t.ifError(err, 'no close error')

--- a/test/test.js
+++ b/test/test.js
@@ -18,11 +18,7 @@ require('abstract-leveldown/abstract/batch-test').all(leveljs, tape, testCommon)
 require('abstract-leveldown/abstract/chained-batch-test').all(leveljs, tape, testCommon)
 require('abstract-leveldown/abstract/close-test').close(leveljs, tape, testCommon)
 require('abstract-leveldown/abstract/iterator-test').all(leveljs, tape, testCommon)
-
-// NOTE: exclude this because the handling of buffers is inconsistent between
-// iterator-test and ranges-test. We can't make both pass, but that's OK, as
-// ranges-test is removed in a later abstract-leveldown version anyway.
-// require('abstract-leveldown/abstract/ranges-test').all(leveljs, tape, testCommon)
+require('abstract-leveldown/abstract/iterator-range-test').all(leveljs, tape, testCommon)
 
 // non abstract-leveldown tests:
 require('./custom-tests.js').all(leveljs, tape, testCommon)

--- a/test/test.js
+++ b/test/test.js
@@ -5,15 +5,13 @@ var testCommon = require('./testCommon')
 // load IndexedDBShim in the tests
 require('./idb-shim.js')()
 
-var testBuffer = Buffer.from('foo')
-
 /*** compatibility with basic LevelDOWN API ***/
 require('abstract-leveldown/abstract/leveldown-test').args(leveljs, tape, testCommon)
 require('abstract-leveldown/abstract/open-test').open(leveljs, tape, testCommon)
 require('abstract-leveldown/abstract/put-test').all(leveljs, tape, testCommon)
 require('abstract-leveldown/abstract/del-test').all(leveljs, tape, testCommon)
 require('abstract-leveldown/abstract/get-test').all(leveljs, tape, testCommon)
-require('abstract-leveldown/abstract/put-get-del-test').all(leveljs, tape, testCommon, testBuffer)
+require('abstract-leveldown/abstract/put-get-del-test').all(leveljs, tape, testCommon)
 require('abstract-leveldown/abstract/batch-test').all(leveljs, tape, testCommon)
 require('abstract-leveldown/abstract/chained-batch-test').all(leveljs, tape, testCommon)
 require('abstract-leveldown/abstract/close-test').close(leveljs, tape, testCommon)


### PR DESCRIPTION
This is the big one. Upgrades to latest `abstract-leveldown` and `levelup`, adds support for binary keys and removes `options.raw`.

Closes #75, closes #65, closes #64, closes #62, closes #59, closes #58, closes #48 (but instead of converting buffer keys to arrays I opted for `String(key)`), closes #40.